### PR TITLE
マイグレーションファイルの修正

### DIFF
--- a/app/assets/javascripts/modules/comment.js
+++ b/app/assets/javascripts/modules/comment.js
@@ -31,7 +31,7 @@ $(function(){
       $('.comment-form__comment-btn').prop('disabled', false);
     })
     .fail(function(){
-      alert('error');
+      alert('コメントを入力してください');
     })
   })
 })

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -3,7 +3,9 @@ class CommentsController < ApplicationController
     @comment = Comment.create(comment_params)
     respond_to do |format|
       format.html { redirect_to product_path(params[:product_id]) }
-      format.json
+      if @comment.save
+        format.json
+      end
     end
   end
 


### PR DESCRIPTION
# What
空のコメントが投稿できていたため、
コメントが空の場合（DBに保存されなかった場合）、エラーメッセージが表示されるよう修正。

# Why
空のメッセージが投稿されることで、余分な情報が増えることを防ぐため。